### PR TITLE
Remove second property from FixtureTime struct

### DIFF
--- a/sub_type.go
+++ b/sub_type.go
@@ -39,7 +39,6 @@ type (
 			Timezone  string `json:"timezone"`
 		} `json:"starting_at"`
 		Minute      int  `json:"minute"`
-		Second      *int `json:"second"`
 		AddedTime   *int `json:"added_time"`
 		ExtraMinute *int `json:"extra_minute"`
 		InjuryTime  *int `json:"injury_time"`


### PR DESCRIPTION
The SportMonks API is inconsistent with this field so I'm removing this as I don't see it as a vital data field for what we need.